### PR TITLE
Added closeModalOnOverlayPress to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,3 +98,4 @@ Prop                | Type     | Optional | Default      | Description
 `optionContainerStyle`| object | Yes      | {}           | style definitions for the option container element
 `cancelStyle`       | object   | Yes      | {}           | style definitions for the cancel element
 `cancelTextStyle`   | object   | Yes      | {}           | style definitions for the cancel text element
+`closeModalOnOverlayPress`| bool   | Yes  | false        | `true` makes the modal close when the overlay is pressed


### PR DESCRIPTION
If you choose to merge my previous pull request you can merge this one as well and it will add information about the closeModalOnOverlayPress prop to the documentation in the ReadMe.